### PR TITLE
Samuel schmitz/parser robustness

### DIFF
--- a/bin/pyir
+++ b/bin/pyir
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import pyir.arg_parse
 import pyir.factory

--- a/pyir/parsers.py
+++ b/pyir/parsers.py
@@ -73,7 +73,7 @@ class SignificantAlignmentParser(BaseParser):
     def __init__(self):
 
         self.trigger_regex = re.compile('^Sequences producing significant alignments')
-        self.hit_regex = re.compile('^(\S*)\s*(\S*)\s*(\S*)')
+        self.hit_regex = re.compile('(.*?)[ ]+([0-9.\-e]+)[ ]+([0-9.\-e]+)')
         self.halt_regex = re.compile('^Domain classification requested')
         self.hits = []
         self.triggered = False


### PR DESCRIPTION
As reported in #3 a malformed regular expression causes igblastn output to be wrongly parsed.
This error occurs with the provided tests `bash SetupGermlineLibrary.sh`.
It can be triggered with sequence names that contain white spaces.
This commit fixes the regular expression accordingly.