### PR TITLE
Make sure igblastn is executable

### DIFF
--- a/pyir/arg_parse.py
+++ b/pyir/arg_parse.py
@@ -225,6 +225,11 @@ class PyIrArgumentParser():
 
         for binary in igblasts:
             try:
+                import stat
+                os.chmod(binary, stat.S_IEXEC)
+            except:
+                pass
+            try:
                 subprocess.check_call([binary, '-h'],stdout=subprocess.PIPE, stderr=subprocess.PIPE)
                 return os.path.abspath(binary)
             except:


### PR DESCRIPTION
Fresh installations tend to suffer from igblastn not being
executable which makes _validate_executable fail.

The patch attempts to make igblastn executable using os.chmod (remains quiet if that fails)