### PR TITLE
hot fix for parsers

### DIFF
--- a/pyir/parsers.py
+++ b/pyir/parsers.py
@@ -729,4 +729,5 @@ class AirrParser():
 
                 self.total_parsed += 1
 
-        self.out_file.close()
+        if self.args['outfmt'] != 'dict':
+            self.out_file.close()


### PR DESCRIPTION
Since `self.out` can either be a dictionary or method, it must be guarded by an it all times. If not, then this method fails for PyIR API type calls that return dictionaries.