### PR TITLE
Fix airr no fr4 issue

### DIFF
--- a/pyir/parsers.py
+++ b/pyir/parsers.py
@@ -713,8 +713,10 @@ class AirrParser():
                             d['fwr4'] = d['sequence_alignment'][matched_cdr3.end():]
                             d['fwr4_aa'] = d['sequence_alignment_aa'][matched_cdr3_aa.end():]
                             if d['fwr4'] and d['fwr4_aa']:
-                                d['fwr4_start'] = re.search(d['fwr4'], d['sequence']).start()+1
-                                d['fwr4_end'] = re.search(d['fwr4'], d['sequence']).end()
+                                d['fwr4'] = d['fwr4'].replace('-', '')
+                                if re.search(d['fwr4'], d['sequence']):
+                                    d['fwr4_start'] = re.search(d['fwr4'], d['sequence']).start()+1
+                                    d['fwr4_end'] = re.search(d['fwr4'], d['sequence']).end()
 
                 if should_write:
                     if self.args['outfmt'] == 'lsjson':

--- a/pyir/parsers.py
+++ b/pyir/parsers.py
@@ -704,6 +704,18 @@ class AirrParser():
                 d['j_family'] = d['j_call'].split(',')[0].split('*')[0]
                 d['cdr3_aa_length'] = len(d['cdr3_aa'])
 
+                # FR4 check
+                if not d['fwr4'] and not d['fwr4_aa']:
+                    if d['cdr3'] and d['cdr3_aa'] and d['productive'] == 'T':
+                        matched_cdr3 = re.search(d['cdr3'], d['sequence_alignment'])
+                        matched_cdr3_aa = re.search(d['cdr3_aa'], d['sequence_alignment_aa'])
+                        if matched_cdr3 and matched_cdr3_aa:
+                            d['fwr4'] = d['sequence_alignment'][matched_cdr3.end():]
+                            d['fwr4_aa'] = d['sequence_alignment_aa'][matched_cdr3_aa.end():]
+                            if d['fwr4'] and d['fwr4_aa']:
+                                d['fwr4_start'] = re.search(d['fwr4'], d['sequence']).start()+1
+                                d['fwr4_end'] = re.search(d['fwr4'], d['sequence']).end()
+
                 if should_write:
                     if self.args['outfmt'] == 'lsjson':
                         if self.args['pretty']:


### PR DESCRIPTION
* fixes the missing d['fwr4'] in airr output when d['cdr3'] is present, also fill the value for ['fwr4_start'] and ['fwr4_end']

* makes sure ['fwr4_start'] and ['fwr4_end'] value being correct when there is special character '-' found in fwr4 in rare cases 

